### PR TITLE
Merging working SSL config

### DIFF
--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -2,24 +2,24 @@ events {}
 http {
     server {
 
-        listen 80 default_server;
-        listen [::]:80 default_server;
-        server_name 192.168.1.200;
-        return 301 https://$server_name$request_uri;
+        listen [::]:80 ipv6only=off default_server;
+        server_name ninjaflix.dennisstine.dev;
+        location / {
+            return 301 https://$server_name$request_uri;
+        }
     }
     server {
-        listen 443 ssl default_server;
-        listen [::]:443 ssl default_server;
+        listen [::]:443 ipv6only=off default_server;
 
         include self-signed.conf;
         include ssl-params.conf;
 
-        server_name 192.168.1.200;
+        server_name ninjaflix.dennisstine.dev;
         server_tokens off;
 
         location / {
             root   /usr/share/nginx/html;
-            index  index.html index.htm;
+            index  index.html;
             try_files $uri /index.html;
         }
     }

--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -1,5 +1,6 @@
 events {}
 http {
+    include /etc/nginx/mime.types;
     server {
 
         listen 80 default_server;

--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -2,14 +2,14 @@ events {}
 http {
     server {
 
-        listen [::]:80 ipv6only=off default_server;
+        listen 80 default_server;
         server_name ninjaflix.dennisstine.dev;
         location / {
             return 301 https://$server_name$request_uri;
         }
     }
     server {
-        listen [::]:443 ipv6only=off default_server;
+        listen 443 ssl default_server;
 
         include self-signed.conf;
         include ssl-params.conf;

--- a/.nginx/self-signed.conf
+++ b/.nginx/self-signed.conf
@@ -1,3 +1,3 @@
-ssl_certificate /etc/ssl/certs/nginx-ninjaflix.dennisstine.dev.crt;
-ssl_certificate_key /etc/ssl/private/nginx-ninjaflix.dennisstine.dev.key;
+ssl_certificate /etc/letsencrypt/live/ninjaflix.dennisstine.dev/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/ninjaflix.dennisstine.dev/privkey.pem;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,6 @@ RUN npm run build
 # Use official .nginx image as the base image
 FROM nginx:latest
 
-# Generate self-signed cert
-RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-    -keyout /etc/ssl/private/nginx-ninjaflix.dennisstine.dev.key \
-    -out /etc/ssl/certs/nginx-ninjaflix.dennisstine.dev.crt \
-    -subj "/C=US/ST=Missouri/L=De Soto/O=Ninjaflix/OU=IT/CN=localhost"
-
 # Copy the .nginx conf that handles routing
 COPY .nginx/nginx.conf /etc/nginx/nginx.conf
 
@@ -24,5 +18,4 @@ COPY .nginx/ssl-params.conf /etc/nginx/ssl-params.conf
 # Copy the build output to replace the default .nginx contents.
 COPY --from=build /usr/local/app/build/ /usr/share/nginx/html
 
-EXPOSE 80
-EXPOSE 443
+EXPOSE 80 443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - /etc/letsencrypt/live/ninjaflix.dennisstine.dev/fullchain.pem:/etc/letsencrypt/live/ninjaflix.dennisstine.dev/fullchain.pem
       - /etc/letsencrypt/live/ninjaflix.dennisstine.dev/privkey.pem:/etc/letsencrypt/live/ninjaflix.dennisstine.dev/privkey.pem
+      - /etc/nginx/mime.types:/etc/nginx/mime.types
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,7 @@ services:
     container_name: server-home-page
     hostname: plex-server
     image: dennisstine/media-server-home
-#    volumes:
-#      - /etc/ssl/certs/nginx-ninjaflix.dennisstine.dev.crt:/etc/ssl/certs/nginx-ninjaflix.dennisstine.dev.crt
-#      - /etc/ssl/private/nginx-ninjaflix.dennisstine.dev.key:/etc/ssl/private/nginx-ninjaflix.dennisstine.dev.key
     ports:
       - "8088:80"
       - "8443:443"
+    command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     hostname: plex-server
     image: dennisstine/media-server-home
     ports:
-      - "8088:80"
-      - "8443:443"
+      - "80:80"
+      - "443:443"
     command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     container_name: server-home-page
     hostname: plex-server
     image: dennisstine/media-server-home
+    volumes:
+      - /etc/letsencrypt/live/ninjaflix.dennisstine.dev/fullchain.pem:/etc/letsencrypt/live/ninjaflix.dennisstine.dev/fullchain.pem
+      - /etc/letsencrypt/live/ninjaflix.dennisstine.dev/privkey.pem:/etc/letsencrypt/live/ninjaflix.dennisstine.dev/privkey.pem
     ports:
       - "80:80"
       - "443:443"

--- a/notes.txt
+++ b/notes.txt
@@ -36,4 +36,5 @@ Generating DH parameters, 2048 bit long safe prime
 
 
 
-https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71
+
+certbot certonly --expand -d ninjaflix.dennisstine.dev

--- a/open_firewall.sh
+++ b/open_firewall.sh
@@ -1,10 +1,9 @@
 sudo firewall-cmd --get-active-zones
 
 sudo firewall-cmd --zone=docker --add-service=http --permanent
-sudo firewall-cmd --zone=docker --add-service=httpd --permanent
+sudo firewall-cmd --zone=docker --add-service=https --permanent
 sudo firewall-cmd --zone=docker --add-service=dns --permanent
 sudo firewall-cmd --zone=docker --add-service=dhcpv6-client --permanent
-sudo firewall-cmd --zone=docker --add-port=443/tcp --permanent
 
 sudo firewall-cmd --reload
 

--- a/open_firewall.sh
+++ b/open_firewall.sh
@@ -1,0 +1,11 @@
+sudo firewall-cmd --get-active-zones
+
+sudo firewall-cmd --zone=docker --add-service=http --permanent
+sudo firewall-cmd --zone=docker --add-service=httpd --permanent
+sudo firewall-cmd --zone=docker --add-service=dns --permanent
+sudo firewall-cmd --zone=docker --add-service=dhcpv6-client --permanent
+sudo firewall-cmd --zone=docker --add-port=443/tcp --permanent
+
+sudo firewall-cmd --reload
+
+sudo firewall-cmd --zone=docker --list-services

--- a/open_firewall.sh
+++ b/open_firewall.sh
@@ -1,10 +1,10 @@
 sudo firewall-cmd --get-active-zones
 
-sudo firewall-cmd --zone=docker --add-service=http --permanent
-sudo firewall-cmd --zone=docker --add-service=https --permanent
-sudo firewall-cmd --zone=docker --add-service=dns --permanent
-sudo firewall-cmd --zone=docker --add-service=dhcpv6-client --permanent
+sudo firewall-cmd --zone=FedoraServer --add-service=http --permanent
+sudo firewall-cmd --zone=FedoraServer --add-service=https --permanent
+sudo firewall-cmd --zone=FedoraServer --add-service=dns --permanent
+sudo firewall-cmd --zone=FedoraServer --add-service=dhcpv6-client --permanent
 
 sudo firewall-cmd --reload
 
-sudo firewall-cmd --zone=docker --list-services
+sudo firewall-cmd --zone=FedoraServer --list-services


### PR DESCRIPTION
Config uses a single subdomain (ninjaflix.dennisstine.dev) with subsequent paths (/plex, /radarr, etc).

This causes issues for apps like Plex and cAdvisor which append paths to roots during redirects.  This could be handled by more nginx proxy_pass and redirects, but a cleaner way will be phase 2: using multiple subdomains.

